### PR TITLE
Compatibility with Rails 4 - ApplicationRecord vs. ActiveRecord::Base

### DIFF
--- a/lib/devise-security/models/active_record/old_password.rb
+++ b/lib/devise-security/models/active_record/old_password.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class OldPassword < ApplicationRecord
+class OldPassword < ActiveRecord::Base
   belongs_to :password_archivable, polymorphic: true
 end


### PR DESCRIPTION
This PR https://github.com/devise-security/devise-security/pull/76 intended to add Mongoid support had this commit https://github.com/devise-security/devise-security/commit/596696d2df4eada853ec72c32018449252aacad0#diff-9fd2d1ec60d420f04b7daa81b3fa653d that was Rails 5 specific.